### PR TITLE
Create silver stations model

### DIFF
--- a/dbt_transformations/models/silver/stations.sql
+++ b/dbt_transformations/models/silver/stations.sql
@@ -1,0 +1,31 @@
+{{ config(materialized='table') }}
+
+WITH parsed_stations AS (
+    SELECT
+        station_id,
+        JSON_VALUE(station_data, '$.name') AS name,
+        JSON_VALUE(station_data, '$.short_name') AS short_name,
+        JSON_VALUE(station_data, '$.region_id') AS region_id,
+        CAST(JSON_VALUE(station_data, '$.lat') AS FLOAT64) AS lat,
+        CAST(JSON_VALUE(station_data, '$.lon') AS FLOAT64) AS lon,
+        JSON_VALUE(station_data, '$.external_id') AS external_id,
+        CAST(JSON_VALUE(station_data, '$.has_kiosk') AS BOOL) AS has_kiosk,
+        CAST(JSON_VALUE(station_data, '$.eightd_has_key_dispenser') AS BOOL) AS eightd_has_key_dispenser,
+        CAST(JSON_VALUE(station_data, '$.electric_bike_surcharge_waiver') AS BOOL) AS electric_bike_surcharge_waiver,
+        CAST(JSON_VALUE(station_data, '$.capacity') AS INT64) AS capacity,
+        JSON_VALUE(station_data, '$.station_type') AS station_type,
+        station_data,
+        api_last_updated,
+        api_version,
+        _ingested_at
+    FROM {{ source('raw', 'citibike_stations') }}
+
+)
+
+SELECT *
+FROM parsed_stations
+QUALIFY 
+    ROW_NUMBER() OVER (
+        PARTITION BY station_id
+        ORDER BY _ingested_at DESC
+    ) = 1

--- a/dbt_transformations/models/sources.yml
+++ b/dbt_transformations/models/sources.yml
@@ -25,3 +25,16 @@ sources:
             description: "Trip end timestamp" 
           - name: _batch_key
             description: "Batch identifier for incremental processing"
+      - name: citibike_stations
+        description: "Station data from GBFS feed"
+        columns:
+          - name: station_id
+            description: "Unique id of station"
+          - name: station_data
+            description: "JSON string of station data from GBFS"
+          - name: api_last_updated
+            description: "Timestamp of last update to stations"
+          - name: api_version
+            desccription: "GBFS api version"
+          - name: _ingested_at
+            description: "When the GBFS data was accessed"


### PR DESCRIPTION
**Changes in this PR**

- Creates the dbt transformations for the silver stations model
- Raw stations are a record of all station data we've collected, while silver stations are the LATEST state of each station in raw (including stations that are no longer active)

**Next steps**
- Enrich with an `is_active` column
- Use station data to infer short_name style station_id for pre-2020 trips