### PR TITLE
Fix gold_commuter_hubs to count all network nodes

### DIFF
--- a/dbt_transformations/models/gold/gold_commuter_hubs.sql
+++ b/dbt_transformations/models/gold/gold_commuter_hubs.sql
@@ -22,25 +22,25 @@ out_degree AS (
 )
 
 SELECT
-  ind.station_id,
+  COALESCE(ind.station_id, outd.station_id) AS station_id,
   s.name,
   s.borough,
   s.capacity,
-  ind.in_degree,
-  outd.out_degree,
-  ind.in_degree + outd.out_degree AS total_degree,
-  ind.weighted_in_degree,
-  outd.weighted_out_degree,
-  ind.weighted_in_degree + outd.weighted_out_degree AS weighted_total_degree
+  COALESCE(ind.in_degree, 0) AS in_degree,
+  COALESCE(outd.out_degree, 0) AS out_degree,
+  COALESCE(ind.in_degree, 0) + COALESCE(outd.out_degree, 0) AS total_degree,
+  COALESCE(ind.weighted_in_degree, 0) AS weighted_in_degree,
+  COALESCE(outd.weighted_out_degree, 0) AS weighted_out_degree,
+  COALESCE(ind.weighted_in_degree, 0) + COALESCE(outd.weighted_out_degree, 0) AS weighted_total_degree
 FROM
   in_degree ind
-JOIN
+FULL OUTER JOIN
   out_degree outd
 ON
   ind.station_id = outd.station_id
 LEFT JOIN
   {{ ref('silver_stations') }} s
 ON
-  ind.station_id = s.short_name
+  COALESCE(ind.station_id, outd.station_id) = s.short_name
 ORDER BY
   weighted_total_degree DESC, s.name


### PR DESCRIPTION
The `gold_commuter_hubs` transformation calculated an `indegree` result set of all station_ids where a given id was the ending station, then calculated an `outdegree` set of all station_ids where a given id was the starting station. The final step joined the two result sets to combine and calculate the total indegree and outdegree of each station.

However, by using a default `JOIN`, which is an inner join, we only included nodes that were both a starting node _and_ an ending node. This choice omitted all true source and sink nodes from the network, where a station_id was found in only one of the two sets.

What is required here is a full outer join, which in turn requires some care because the result for sink and source nodes will have only one non-null station_id and only one set of non-null values for in/out degree and weighted in/out degree.