### PR TITLE
Update station performance dashboard

### DIFF
--- a/dbt_transformations/models/gold/analytics/gold_station_performance_dashboard.sql
+++ b/dbt_transformations/models/gold/analytics/gold_station_performance_dashboard.sql
@@ -5,58 +5,160 @@
 ) }}
 
 WITH latest_data_date AS (
-    SELECT MAX(DATE(started_at)) as max_date
-    FROM {{ ref('silver_trips') }}
+    SELECT MAX(DATE(started_at)) AS max_date
+    FROM {{ ref('gold_fact_trips') }}
+),
+
+data_start_date AS (
+    SELECT
+        max_date,
+        DATE_SUB(DATE_TRUNC(max_date, MONTH), INTERVAL 2 MONTH) AS start_date
+    FROM
+        latest_data_date
 ),
 
 date_range AS (
-    SELECT 
+    SELECT
         max_date,
-        DATE_SUB(DATE_TRUNC(max_date, MONTH), INTERVAL 2 MONTH) as start_date
-    FROM latest_data_date
+        start_date, 
+        DATE_DIFF(max_date, start_date, DAY) AS actual_days
+    FROM data_start_date
+),
+
+recent_trips AS (
+    SELECT * 
+    FROM {{ ref('gold_fact_trips') }}
+    WHERE date_key >= (SELECT start_date FROM date_range)
+        AND NOT is_data_integrity_issue
+        AND NOT is_geography_quality_issue
+        AND NOT is_temporal_outlier
+        AND NOT is_duplicate_ride
 ),
 
 station_activity AS (
-    SELECT start_station_id as station_id, COUNT(*) as starts, 0 as ends
-    FROM {{ ref('silver_trips') }}
-    WHERE DATE(started_at) >= (SELECT start_date from date_range)
-        AND NOT {{ is_geographic_outlier('start_lat', 'start_lng') }}
-        AND NOT {{ is_geographic_outlier('end_lat', 'end_lng') }}
+    SELECT 
+        start_station_id AS station_id, 
+        COUNT(*) AS starts, 
+        0 AS ends,
+    FROM recent_trips
     GROUP BY 1
-  
+    
     UNION ALL
-  
-    SELECT end_station_id as station_id, 0 as starts, COUNT(*) as ends  
-    FROM {{ ref('silver_trips') }}
-    WHERE DATE(started_at) >= (SELECT start_date from date_range)
-        AND NOT {{ is_geographic_outlier('start_lat', 'start_lng') }}
-        AND NOT {{ is_geographic_outlier('end_lat', 'end_lng') }}
+    
+    SELECT 
+        end_station_id AS station_id, 
+        0 AS starts, 
+        COUNT(*) AS ends,
+    FROM recent_trips
     GROUP BY 1
+),
+
+aggregated_activity AS (
+    SELECT 
+        station_id,
+        SUM(starts) AS total_starts,
+        SUM(ends) AS total_ends,
+        SUM(starts) + SUM(ends) AS total_activity,
+        SUM(ends) - SUM(starts) AS net_inflow,  -- Positive = gaining bikes, negative = losing bikes
+    FROM station_activity
+    GROUP BY station_id
+),
+
+daily_rush_hour_patterns AS (
+    SELECT 
+        rt.start_station_id AS station_id,
+        rt.date_key,
+        dd.day_of_week,
+        -- Morning rush daily min/max per station
+        MIN(CASE WHEN rt.start_hour BETWEEN 7 AND 10 THEN rt.start_station_running_bike_balance END) AS daily_morning_min,
+        MAX(CASE WHEN rt.start_hour BETWEEN 7 AND 10 THEN rt.start_station_running_bike_balance END) AS daily_morning_max,
+        -- Evening rush daily min/max per station  
+        MIN(CASE WHEN rt.start_hour BETWEEN 17 AND 20 THEN rt.start_station_running_bike_balance END) AS daily_evening_min,
+        MAX(CASE WHEN rt.start_hour BETWEEN 17 AND 20 THEN rt.start_station_running_bike_balance END) AS daily_evening_max
+    FROM recent_trips rt
+    JOIN {{ ref('gold_dim_dates') }} dd 
+    ON rt.date_key = dd.date_key
+    WHERE NOT dd.is_weekend
+    GROUP BY rt.start_station_id, rt.date_key, dd.day_of_week
+),
+
+station_rush_hour_metrics AS (
+    SELECT 
+        station_id,
+        -- Average of daily minimums/maximums
+        AVG(daily_morning_min) AS avg_daily_morning_min,
+        AVG(daily_morning_max) AS avg_daily_morning_max,
+        AVG(daily_evening_min) AS avg_daily_evening_min,
+        AVG(daily_evening_max) AS avg_daily_evening_max,
+        -- Daily swing patterns
+        AVG(daily_morning_max - daily_morning_min) AS avg_morning_daily_swing,
+        AVG(daily_evening_max - daily_evening_min) AS avg_evening_daily_swing
+    FROM daily_rush_hour_patterns
+    WHERE daily_morning_min IS NOT NULL OR daily_evening_min IS NOT NULL
+    GROUP BY station_id
 )
 
 SELECT 
-    s.name as station_name,
-    s.borough,
-    s.lat,
-    s.lon,
-    s.capacity,
-    sa.station_id,
-    SUM(sa.starts) as total_starts,
-    SUM(sa.ends) as total_ends,
-    SUM(sa.starts) + SUM(sa.ends) as total_activity,
+    ds.station_id,
+    ds.station_name,
+    ds.borough,
+    ds.lat,
+    ds.lon,
+    ds.capacity,
+    ds.is_active,
+    
+    -- Recent activity metrics (last ~90 days)
+    COALESCE(aa.total_starts, 0) AS recent_starts,
+    COALESCE(aa.total_ends, 0) AS recent_ends,
+    COALESCE(aa.total_activity, 0) AS recent_activity,
+    COALESCE(aa.net_inflow, 0) AS recent_net_inflow,  -- Positive = gaining bikes
+    
     -- Performance metrics
-    ROUND((SUM(sa.starts) + SUM(sa.ends)) / 90.0, 1) as avg_daily_activity,
     CASE 
-        WHEN s.capacity > 0 THEN ROUND((SUM(sa.starts) + SUM(sa.ends)) / (90.0 * s.capacity), 2)
+        WHEN (SELECT actual_days FROM date_range) > 0 
+        THEN ROUND(COALESCE(aa.total_activity, 0) / (SELECT actual_days FROM date_range), 1)
         ELSE NULL 
-    END as activity_per_dock_per_day,
-    -- Imbalance indicators  
-    SUM(sa.starts) - SUM(sa.ends) as net_outflow,
+    END AS avg_daily_activity,
     CASE 
-        WHEN (SUM(sa.starts) + SUM(sa.ends)) > 0 
-        THEN ROUND((SUM(sa.starts) - SUM(sa.ends)) / (SUM(sa.starts) + SUM(sa.ends)) * 100, 1)
+        WHEN ds.capacity > 0 AND (SELECT actual_days FROM date_range) > 0
+        THEN ROUND(COALESCE(aa.total_activity, 0) / ((SELECT actual_days FROM date_range) * ds.capacity), 2)
         ELSE NULL 
-    END as imbalance_pct
-FROM station_activity sa
-JOIN {{ ref('silver_stations') }} s ON sa.station_id = s.short_name
-GROUP BY s.name, s.borough, s.lat, s.lon, s.capacity, sa.station_id
+    END AS activity_per_dock_per_day,
+    
+    -- Imbalance metrics
+    CASE 
+        WHEN COALESCE(aa.total_activity, 0) > 0 
+        THEN ROUND(COALESCE(aa.net_inflow, 0) / aa.total_activity * 100, 1)
+        ELSE NULL 
+    END AS imbalance_ratio,  -- Positive = station gaining bikes
+    
+    -- Rush hour operational patterns (weekdays only)
+    ROUND(srh.avg_daily_morning_min, 1) AS avg_daily_morning_min_bike_balance,
+    ROUND(srh.avg_daily_morning_max, 1) AS avg_daily_morning_max_bike_balance,
+    ROUND(srh.avg_daily_evening_min, 1) AS avg_daily_evening_min_bike_balance,
+    ROUND(srh.avg_daily_evening_max, 1) AS avg_daily_evening_max_bike_balance,
+    ROUND(srh.avg_morning_daily_swing, 1) AS avg_morning_daily_bike_balance_swing,
+    ROUND(srh.avg_evening_daily_swing, 1) AS avg_evening_daily_bike_balance_swing,
+
+    CASE
+        WHEN COALESCE(ds.capacity, 0) > 0
+        THEN ROUND((avg_morning_daily_swing / capacity), 2)
+        ELSE NULL
+    END AS balance_swing_ratio_morning,
+
+    CASE
+        WHEN COALESCE(ds.capacity, 0) > 0
+        THEN ROUND((avg_evening_daily_swing / capacity), 2)
+        ELSE NULL
+    END AS balance_swing_ratio_evening,
+
+FROM 
+    {{ ref('gold_dim_stations') }} ds
+LEFT JOIN 
+    aggregated_activity aa
+ON
+    ds.station_id = aa.station_id
+LEFT JOIN 
+    station_rush_hour_metrics srh
+ON
+    ds.short_name = srh.station_id


### PR DESCRIPTION
** Changes in this PR **

This PR updates the station performance dashboard with a mixture of refactors, which have no anticipated change in outputs, and new features.

_Refactors_
- Read from updated gold fact and dimension tables wherever possible

_New features_
- Make use of data quality flags to filter out questionable source data
- New metrics for the average daily min/max running bike balance during morning and evening commutes
- This includes "balance ratio" metrics for morning and evening commute, which attempt to measure whether the average swing in bike balance exceeds the station's capacity. A ratio of 1.0 or greater indicates that the station is too small, a candidate for expansion, or a candidate for human-powered measures to rebalance bikes at that station.
- Flip the sign of the imbalance and net _flow metrics to align with the running bike balance. Negative means bikes are going out; positive means bikes are coming in