### PR TITLE
add dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+.venv/
+logs/
+*.egg-info/
+__pycache__/
+airflow.cfg
+webserver_config.py
+airflow-webserver.pid


### PR DESCRIPTION
This change currently does nothing but will prevent inessential or insecure files from being included in any layers of the built container image when doing a `COPY` operation.