### PR TITLE
Update description of boundaries pipeline

### DIFF
--- a/dags/boundaries_pipeline.py
+++ b/dags/boundaries_pipeline.py
@@ -20,7 +20,7 @@ default_args = {
 dag = DAG(
     'boundaries_pipeline',
     default_args=default_args,
-    description='Get NYC borough boundaries geojson from API and persist to BigQuery',
+    description='Get NYC borough boundaries geojson from JSON datafile and persist to BigQuery',
     schedule_interval=None,  # Manual trigger only (no automatic scheduling)
     catchup=False,  # Don't run for past dates
     tags=['citibike'],


### PR DESCRIPTION
This should have been done in #38 to reflect that this pipeline no longer fetches boundaries data from the API on each run, but instead uses existing static data.