### PR TITLE
Remove `validate_connection=True` arguments in calling code

### DIFF
--- a/citibike/ingestion/borough_boundaries.py
+++ b/citibike/ingestion/borough_boundaries.py
@@ -28,7 +28,7 @@ def ingest_borough_boundaries():
     print(f"Prepared {len(rows)} borough boundaries for ingestion")
 
     # Insert to BigQuery
-    client = initialize_bigquery_client(validate_connection=True)
+    client = initialize_bigquery_client()
     table_id = f"{os.environ['GCP_PROJECT_ID']}.{os.environ['BQ_DATASET']}.raw_nyc_borough_boundaries"
 
     errors = client.insert_rows_json(table_id, rows)

--- a/citibike/ingestion/stations.py
+++ b/citibike/ingestion/stations.py
@@ -52,7 +52,7 @@ def ingest_station_data(batch_date: datetime) -> None:
     df['api_version'] = df['api_version'].astype(str)
 
     # Initialize BigQuery client 
-    client = initialize_bigquery_client(validate_connection=True)
+    client = initialize_bigquery_client()
 
     # Build table reference
     table_id = f"{os.environ['GCP_PROJECT_ID']}.{os.environ['BQ_DATASET']}.raw_stations"

--- a/citibike/ingestion/trips.py
+++ b/citibike/ingestion/trips.py
@@ -22,7 +22,7 @@ def _ingest_trip_data(year: int, month: int, table_name: str, schema: Dict[str, 
     """Download and ingest trip data for the given month, table, and schema."""
     # Initialize components
     storage = LocalStorage()
-    client = initialize_bigquery_client(validate_connection=True)
+    client = initialize_bigquery_client()
     table_id = f"{os.environ['GCP_PROJECT_ID']}.{os.environ['BQ_DATASET']}.{table_name}"
     loader = StagingTableLoader(client, table_id, "_batch_key")
 

--- a/citibike/networks/analysis.py
+++ b/citibike/networks/analysis.py
@@ -7,7 +7,7 @@ import networkx as nx
 
 class CommuterNetworkAnalyzer:
     def __init__(self):
-        self.client: bigquery.Client  = initialize_bigquery_client(validate_connection=True)
+        self.client: bigquery.Client  = initialize_bigquery_client()
         self.project_id = os.environ['GCP_PROJECT_ID']
         self.dataset = os.environ['BQ_DATASET']
         self.SUPER_SOURCE = "super_source"

--- a/create_tables.py
+++ b/create_tables.py
@@ -38,7 +38,7 @@ def run() -> None:
     if not dataset_name or not project_id:
         raise SystemExit(f"Missing required environment variables BQ_DATASET or GCP_PROJECT_ID. BQ_DATASET={dataset_name}, GCP_PROJECT_ID={project_id}")
 
-    client = initialize_bigquery_client(validate_connection=True)
+    client = initialize_bigquery_client()
 
     # Prepare list of tables that will be created
     tables_to_create = [f"`{project_id}.{dataset_name}.{table_name}{suffix}`" for table_name in TABLE_NAMES for suffix in TABLE_SUFFIXES]


### PR DESCRIPTION
The `initialize_bigquery_client()` method has a `validate_connection` kwarg that, when `True`, will check that the connection is working by making a call to list the datasets. This can be helpful for debugging but wastes time and usage in day to day operations. This PR leaves the parameter and functionality in `initialize_bigquery_client()` but removes it as arguments passed by any current calling code.